### PR TITLE
Enable find plugin

### DIFF
--- a/src/Main/Main.js
+++ b/src/Main/Main.js
@@ -23,7 +23,16 @@ class Main extends Component {
   static propTypes = {
     mutator: PropTypes.object.isRequired,
     resources: PropTypes.object.isRequired,
-    stripes: PropTypes.object
+    stripes: PropTypes.object,
+    onSelectRow: PropTypes.func,
+    onComponentWillUnmount: PropTypes.func,
+    showSingleResult: PropTypes.bool, // eslint-disable-line react/no-unused-prop-types
+    browseOnly: PropTypes.bool,
+  }
+
+  static defaultProps = {
+    showSingleResult: true,
+    browseOnly: false,
   }
 
   static manifest = Object.freeze({
@@ -240,6 +249,7 @@ class Main extends Component {
   }
 
   render() {
+    const { onSelectRow, onComponentWillUnmount, showSingleResult, browseOnly } = this.props;
     const resultsFormatter = {
       'Name': data => _.get(data, ['name'], ''),
       'Code': data => _.get(data, ['code'], ''),
@@ -275,6 +285,10 @@ class Main extends Component {
             selectedIndex={_.get(this.props.resources.query, 'qindex')}
             searchableIndexesPlaceholder={null}
             onChangeIndex={this.onChangeIndex}
+            onSelectRow={onSelectRow}
+            onComponentWillUnmount={onComponentWillUnmount}
+            browseOnly={browseOnly}
+            showSingleResult={showSingleResult}
           />
         }
       </div>


### PR DESCRIPTION
We (at UB Leipzig) want to create a vendor finder plugin for stripes similar to [ui-plugin-find-user](https://github.com/folio-org/ui-plugin-find-user). In order to create the vendor finder plugin the vendor's SearchAndSort component needs additional properties. This pull request contains these properties.

We want to create the vendor finder plugin to use it in a usage statistics app we are developing. In that app we want to link statistics to certain vendors.