### PR TITLE
UIV-32 Release v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change history for ui-vendors
 
-## 1.1.1 (IN PROGRESS)
+## [1.1.0](https://github.com/folio-org/ui-vendors/tree/v1.1.0) (2018-10-10)
+[Full Changelog](https://github.com/folio-org/ui-vendors/compare/v1.0.1...v1.1.0)
+
 * Removed tags and notes. ref: UIV-27.
 * Moved Sans code field into summary, UIV-21
 * Converted category dropdown to multi select for contact infomartion and contact people. Ref: UIV-4.
@@ -17,6 +19,7 @@
 * Make status field required, Fixes MODVEND-51.
 * Update label "- Please add vendors -" to "- Please add alternative names -". Fixes MODVEND-52.
 * Ignored stripesclirc and stripes.config.js.local. 
+* Switch to `stripes v1.0.0` for core dependencies. UIV-32
 
 ## [1.0.1](https://github.com/folio-org/ui-vendors/tree/v1.0.1) (2018-09-17)
 * Update stripes-form version. Fixes UIV-8.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/vendors",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "Description for ui-vendors",
   "main": "index.js",
   "repository": "",


### PR DESCRIPTION
* Removed tags and notes. ref: UIV-27.
* Moved Sans code field into summary, UIV-21
* Converted category dropdown to multi select for contact infomartion and contact people. Ref: UIV-4.
* Fixed vendor status error highlight. Ref: UIV-12.
* Fixed Agreements discount display. Ref: UIV-3.
* Changed field name ERP code to Accounting Code. UIV-2
* Updated Vendor EDI Code and Library EDI Code component type to TextField. Ref: UIV-5.
* Update component UIV-5
* Added tags, ref: UIV-27.
* Update mismatch languages in email section, phone number section, url section, summary section. ref: UIV-23.
* Add styling on field array in Contact People, Agreements, Interface and Accounts. Fixes UIV-7.
* Update sub-heading styling. Fixes UIV-6.
* Fix Mismatch in terminology between Alias and AKA. Fixes MODVEND-50.
* Make status field required, Fixes MODVEND-51.
* Update label "- Please add vendors -" to "- Please add alternative names -". Fixes MODVEND-52.
* Ignored stripesclirc and stripes.config.js.local. 
* Switch to `stripes v1.0.0` for core dependencies. UIV-32